### PR TITLE
Update risc0.circom for circom-witnesscalc compatibility

### DIFF
--- a/groth16_proof/circuits/risc0.circom
+++ b/groth16_proof/circuits/risc0.circom
@@ -403,7 +403,8 @@ template inv_impl(nInputs) {
   signal input in[1];
   signal output out;
   var P = 15 * (1 << 27) + 1;
-  out <-- inverse(in[0], P);
+  var inv_res = inverse(in[0], P);
+  out <-- inv_res;
   component bits_k = to_bits_exact(31);
   bits_k.in <-- out * in[0] \ P;
   component bits = to_bits_exact(31);


### PR DESCRIPTION
This change won't change the constraints of the circuit but will allow for compatibility with circom-witnesscalc. 
Linked below is the git blame for the same change that happened in the risc0 repo. 

https://github.com/risc0/risc0/blame/f7b7975efe5e1af6b38d65c39d0a314ffe33f177/groth16_proof/groth16/risc0.circom#L406